### PR TITLE
[stack dumper] Get syncd symbols printed in stack dumper

### DIFF
--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -62,6 +62,9 @@ libSyncd_a_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON) $(SAIFLAGS) -s
 
 syncd_SOURCES = main.cpp
 syncd_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON) $(SAIFLAGS)
+if DEBUG
+syncd_LDFLAGS = -rdynamic
+endif
 syncd_LDADD = libSyncd.a ../lib/src/libSaiRedis.a -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -ldl -lhiredis -lswsscommon $(SAILIB) -lpthread -lzmq
 
 if SAITHRIFT


### PR DESCRIPTION
* Add -rdynamic to linking process for syncd when in DEBUG mode

Signed-off-by: Alexandru Banu <Alexandru.Banu@metaswitch.com>