### PR TITLE
Fix VID to RID conversion

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -1492,7 +1492,7 @@ sai_status_t Syncd::processBulkOidRemove(
     status = m_vendorSai->bulkRemove(
                                 objectType,
                                 (uint32_t)object_count,
-                                objectVids.data(),
+                                objectRids.data(),
                                 mode,
                                 statuses.data());
 


### PR DESCRIPTION
Fix dodgy object IDs being passed down over the SAI for bulk-removes of next-hop-objects.